### PR TITLE
Update audio.h

### DIFF
--- a/include/hardware/audio.h
+++ b/include/hardware/audio.h
@@ -148,7 +148,7 @@ __BEGIN_DECLS
 #define AUDIO_OFFLOAD_CODEC_WMA_BIT_PER_SAMPLE "music_offload_wma_bit_per_sample"
 #define AUDIO_OFFLOAD_CODEC_WMA_CHANNEL_MASK "music_offload_wma_channel_mask"
 #define AUDIO_OFFLOAD_CODEC_WMA_ENCODE_OPTION "music_offload_wma_encode_option"
-#define AUDIO_OFFLOAD_CODEC_WMA_ENCODE_OPTION1"music_offload_wma_encode_option1"
+#define AUDIO_OFFLOAD_CODEC_WMA_ENCODE_OPTION1 "music_offload_wma_encode_option1"
 #define AUDIO_OFFLOAD_CODEC_WMA_ENCODE_OPTION2 "music_offload_wma_encode_option2"
 #define AUDIO_OFFLOAD_CODEC_FORMAT  "music_offload_codec_format"
 #define AUDIO_OFFLOAD_CODEC_FLAC_MIN_BLK_SIZE "music_offload_flac_min_blk_size"


### PR DESCRIPTION
hardware/libhardware/include/hardware/audio.h:151:47: warning: missing whitespace after the macro name [enabled by default]
